### PR TITLE
FEAT: App default config

### DIFF
--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -1,4 +1,4 @@
-brokerAddress: tcp://localhost:1883
+brokerAddress: tcp://zuckernas.ddns.net:1883
 topics:
   alertManager:
     subscribe: airports/+

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -1,0 +1,5 @@
+brokerAddress: tcp://localhost:1883
+topics:
+  alertManager:
+    subscribe: airports/+
+    publish: airports/alertManager/

--- a/internal/brokerConfiguration/brokerConfiguration.go
+++ b/internal/brokerConfiguration/brokerConfiguration.go
@@ -1,0 +1,65 @@
+package brokerConfiguration
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	BrokerAddress string `yaml:"brokerAddress"`
+	Topics        struct {
+		AlertManager struct {
+			Subscribe string `yaml:"subscribe"`
+			Publish   string `yaml:"publish"`
+		} `yaml:"alertManager"`
+	} `yaml:"topics"`
+}
+
+func getAppConfig() (Config, error) {
+	yamlFile, err := os.Open("config/app_config.yml")
+	if err != nil {
+		fmt.Println("Error reading app config file:", err)
+		return Config{}, err
+	}
+	defer yamlFile.Close()
+
+	byteValue, _ := io.ReadAll(yamlFile)
+
+	var config Config
+	err = yaml.Unmarshal(byteValue, &config)
+	if err != nil {
+		fmt.Println("Error unmarshalling YAML:", err)
+		return Config{}, err
+	}
+	return config, nil
+}
+
+func GetBrokerAddress() string {
+	config, err := getAppConfig()
+	if err != nil {
+		fmt.Printf("Error getting app config: %v", err)
+		return ""
+	}
+
+	brokerAddress := config.BrokerAddress
+
+	return brokerAddress
+}
+
+func GetAlertManagerTopics() ([]string) {
+	config, err := getAppConfig()
+	if err != nil {
+		fmt.Printf("Error getting app config: %v", err)
+		return []string{}
+	}
+
+	alertManagerTopicSubscribe := config.Topics.AlertManager.Subscribe
+	alertManagerTopicPublish := config.Topics.AlertManager.Publish
+
+	alertManagerTopics := []string{alertManagerTopicSubscribe, alertManagerTopicPublish}
+
+	return alertManagerTopics
+}

--- a/internal/sensors/sensors.go
+++ b/internal/sensors/sensors.go
@@ -4,7 +4,7 @@ import (
 	"ArchiD-Projet/internal/meteofranceAPI"
 	"ArchiD-Projet/internal/mqttconnect"
 	"fmt"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"os"
 	"sync"
 	"time"
@@ -15,7 +15,6 @@ type Sensor struct {
 	qos       byte
 	topic     string
 	retained  bool
-	lastValue string
 	config    SensorConfig
 	info      SensorInfo
 	waitGroup *sync.WaitGroup
@@ -98,16 +97,13 @@ func (sensor *Sensor) StartMonitoring() {
 	go func() {
 		defer sensor.waitGroup.Done()
 		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				sensorData, err := meteofranceAPI.FetchSensorDataFromAPI(meteofranceAPI.SensorInfo(sensor.info))
-				if err != nil {
-					fmt.Println("Error fetching sensor data from API:", err)
-					continue
-				}
-				sensor.PublishSensorData(SensorData(sensorData))
+		for range ticker.C {
+			sensorData, err := meteofranceAPI.FetchSensorDataFromAPI(meteofranceAPI.SensorInfo(sensor.info))
+			if err != nil {
+				fmt.Println("Error fetching sensor data from API:", err)
+				continue
 			}
+			sensor.PublishSensorData(SensorData(sensorData))
 		}
 	}()
 


### PR DESCRIPTION
This feature contains:
* addition of an application default configuration file in YAML to define broker address and topics routes
* fix of a small golang mistake
* removal of an unused variable

This feature does not include:
* update of files that currently use manually setup constants for broker address and topics routes (which might be repeated multiple times in different files)